### PR TITLE
Fix actual and expected being null

### DIFF
--- a/src/graderPublic/java/h10/H3_PublicTests.java
+++ b/src/graderPublic/java/h10/H3_PublicTests.java
@@ -15,8 +15,8 @@ import static h10.PublicTutorUtils.contextH3;
 import static h10.PublicTutorUtils.listItemAsList;
 import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.assertEquals;
 import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.assertNotNull;
-import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.assertNull;
 import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.assertSame;
+import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.assertTrue;
 
 /**
  * Defines the public JUnit test cases related to the task H3.
@@ -89,8 +89,8 @@ public final class H3_PublicTests {
      *     }
      * }</pre>
      *
-     * @param object          the list to test
-     * @param key             the element to add
+     * @param object the list to test
+     * @param key    the element to add
      * @param height the expected height of the list
      */
     @DisplayName("18 | Methode setzt die aktuelle Höhe korrekt.")
@@ -141,11 +141,14 @@ public final class H3_PublicTests {
 
         Context context = contextH3(list, key);
 
-        assertNull(
-            list.head,
+        assertTrue(
+            list.head == null,
             context,
             result -> String.format("The call of the method remove(%s) possibly modified the head to %s, but expected "
-                + "null since we are removing a list containing one element.", key, result.object())
+                    + "null since we are removing a list containing one element.", key,
+                PublicTutorUtils.toString(list.head
+                )
+            )
         );
     }
 
@@ -164,8 +167,8 @@ public final class H3_PublicTests {
      *     }
      * }</pre>
      *
-     * @param object          the list to test
-     * @param key             the element to add
+     * @param object the list to test
+     * @param key    the element to add
      * @param height the expected height of the list after removals
      */
     @DisplayName("20 | Methode entfernt Ebenen mit einem Element korrekt.")

--- a/src/graderPublic/java/h10/PublicTutorUtils.java
+++ b/src/graderPublic/java/h10/PublicTutorUtils.java
@@ -55,6 +55,21 @@ public class PublicTutorUtils {
     private PublicTutorUtils() {
     }
 
+
+    /**
+     * Returns the string representation of the given object where the string representation is the result of the
+     * name of the class followed by the hash code of the object in hexadecimal format.
+     *
+     * @param object the object to represent as a string.
+     *
+     * @return the string representation of the given object.
+     *
+     * @see Object#toString()
+     */
+    public static String toString(Object object) {
+        return object == null ? "null" : object.getClass().getName() + "@" + Integer.toHexString(object.hashCode());
+    }
+
     /**
      * Returns the {@link Criterion} for the given class.
      *

--- a/src/main/java/h10/ListItem.java
+++ b/src/main/java/h10/ListItem.java
@@ -63,7 +63,7 @@ public class ListItem<T> {
 
     @Override
     public String toString() {
-        return String.valueOf(key);
+        return "a ListItem with key: " + key + " and next: " + (next == null ? "null" : next.key);
     }
 
 }


### PR DESCRIPTION
I don't think that this is the best solution to the issue, but it might be an idea.
The issue that has been reported multiple times now is that the expected and actual keys differ, even though both are null.
This stems from the sentinel nodes having the value null, which is the only thing returned in the String representation of the object. Therefore, it might be a good idea to change the toString() method in order to provide more context.
An example of the error this pull request is attempting to address can be found here:
https://discord.com/channels/968818197824417822/1063882508665626624/1064221236688851027